### PR TITLE
(hotfix/temporary workaround) Ignore `prices` Column and Set Default Value to `description`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from setuptools import setup
 
-VERSION = "0.1.3"
+VERSION = "0.1.3a"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/target_bigquery/__init__.py
+++ b/target_bigquery/__init__.py
@@ -208,6 +208,10 @@ def write_records(
             load_config_props.update(load_config_properties)
         load_config = LoadJobConfig(**load_config_props)
 
+        load_config.schema_update_options = [
+            bigquery.SchemaUpdateOption.ALLOW_FIELD_RELAXATION
+        ]
+
         if row_count[table_name] == 0:
             logger.info(f"Zero records for {table}. Skip loading.")
             continue

--- a/target_bigquery/schema.py
+++ b/target_bigquery/schema.py
@@ -22,7 +22,7 @@ def _get_schema_type_mode(property_, numeric_type):
     schema_mode = "NULLABLE"
     if isinstance(type_, list):
         if type_[0] != "null":
-            schema_mode = "REQUIRED"
+            schema_mode = "NULLABLE"
 
         if len(type_) < 2 or type_[1] not in JSONSCHEMA_TYPES:
             # Some major taps contain type first :(
@@ -136,6 +136,17 @@ def clean_and_validate(message, schemas, invalids, on_invalid_record, json_dumps
         )
 
     schema = schemas[message.stream]
+
+    try:
+        del message.record["prices"]
+    except KeyError:
+        pass
+
+    try:
+        if message.record["description"] == None:
+            message.record["description"] = ""
+    except KeyError:
+        pass
 
     try:
         validate(message.record, schema)


### PR DESCRIPTION
**Why is this PR necessary, what does it do?**
This PR removes the `prices` key from loaded messages and also sets a default value to the `description` column on all tables.

**References:**
- Related to [this slack thread](https://jusbrasil.slack.com/archives/C025AG8A810/p1644372201936769).

**Notes:**
- This is a **temporary workaround** that should be reverted ASAP.
